### PR TITLE
[healthcheck] fix https://github.com/InseeFrLab/onyxia-cli/issues/8

### DIFF
--- a/utils/console.go
+++ b/utils/console.go
@@ -21,7 +21,7 @@ func PrintMessage(m string) {
 	fmt.Print(m)
 }
 
-func PrintErrorMessageAndExit(m string) {
+func PrintErrorAndExit(m string) {
 	fmt.Print(m)
 	os.Exit(1)
 }


### PR DESCRIPTION
`PrintErrorMessageAndExit` should be named `PrintErrorAndExit`